### PR TITLE
Remove cashier and buyer from seing 'add user' and 'add product' form.

### DIFF
--- a/src/components/Navigation/Navigation.jsx
+++ b/src/components/Navigation/Navigation.jsx
@@ -1,11 +1,14 @@
 import React from 'react';
 import { Navbar } from 'react-bootstrap';
 import { NavLink, Link } from 'react-router-dom';
+import { useSelector } from 'react-redux';
 import { ReactComponent as Logo } from '../../assets/logo/logo.svg';
-
+import { isManagement } from '../../util/util';
 import './Navigation.css';
 
 export default function Navigation({ children }) {
+  const currentUser = useSelector((state) => state.user);
+
   return (
     <main className="MainNavigation">
       <section className="NavigationSide">
@@ -26,13 +29,15 @@ export default function Navigation({ children }) {
         >
           Products
         </NavLink>
-        <NavLink
-          className="NavigationLink"
-          to="/product-insert"
-          activeClassName="NavigationLinkActive"
-        >
-          Add New Product Type
-        </NavLink>
+        {isManagement(currentUser) && (
+          <NavLink
+            className="NavigationLink"
+            to="/product-insert"
+            activeClassName="NavigationLinkActive"
+          >
+            Add New Product Type
+          </NavLink>
+        )}
         <NavLink
           className="NavigationLink"
           to="/transactions"
@@ -47,13 +52,15 @@ export default function Navigation({ children }) {
         >
           Users
         </NavLink>
-        <NavLink
-          className="NavigationLink"
-          to="/user-insert"
-          activeClassName="NavigationLinkActive"
-        >
-          Add New User
-        </NavLink>
+        {isManagement(currentUser) && (
+          <NavLink
+            className="NavigationLink"
+            to="/user-insert"
+            activeClassName="NavigationLinkActive"
+          >
+            Add New User
+          </NavLink>
+        )}
         <hr />
       </section>
       <div className="NavigationSideContainer" />


### PR DESCRIPTION
This was suggested by the user tester. The tooltips will still help when a buyer or cashier manually types in the url rather than clicking on the navbar link. Owner and manager can still see links.

![Screenshot from 2020-08-13 10-54-09](https://user-images.githubusercontent.com/19937283/90150267-7c8f1f80-dd53-11ea-90b6-696e096d3bb9.png)
![Screenshot from 2020-08-13 10-52-53](https://user-images.githubusercontent.com/19937283/90150272-7e58e300-dd53-11ea-9b3d-598b94c52115.png)
